### PR TITLE
improvement: consolidate rules

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,5 +4,6 @@
     { "repo": "relay-tools/relay-graphql-js" }
   ],
   "commit": false,
-  "access": "public"
+  "access": "public",
+  "baseBranch": "main"
 }

--- a/.changeset/honest-dots-decide.md
+++ b/.changeset/honest-dots-decide.md
@@ -1,0 +1,10 @@
+---
+"@relay-graphql-js/generate-config": minor
+"@relay-graphql-js/graphql-config": minor
+"@relay-graphql-js/validation-rules": minor
+"vscode-apollo-relay": minor
+---
+## Improvements
+
+- use `RelayKnownArgumentNames` in both configs
+- export `validationRules` from core `generateConfig`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@master
-        with:
-          # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits 
-          fetch-depth: 0
 
 
       - name: Setup Node.js 12.x

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,4 +3,14 @@ module.exports = {
   moduleFileExtensions: ["ts", "js", "json"],
   testMatch: ["**/tests/**/*.ts", "**/*.test.ts"],
   transform: { "\\.ts$": "ts-jest" },
+  collectCoverageFrom: [
+    '**/src/**/*.{js,jsx,ts,tsx}',
+    '!**/src/**/*.stories.js*',
+    '!**/{dist,build,esm}/**',
+    '!**/node_modules/**',
+    '!**/__tests__/**',
+    '!**/test/**',
+    '!**/*.d.ts',
+    '!**/typings',
+  ]
 }

--- a/packages/generate-config/package.json
+++ b/packages/generate-config/package.json
@@ -15,5 +15,8 @@
   "peerDependencies": {
     "relay-compiler": ">=5.0.0",
     "relay-config": ">=5.0.0"
+  },
+  "dependencies": {
+    "@relay-graphql-js/validation-rules": "^0.0.1"
   }
 }

--- a/packages/generate-config/src/dependencies.ts
+++ b/packages/generate-config/src/dependencies.ts
@@ -4,7 +4,6 @@
  * e.g. graphql-js parts come from different modules (i.e. the user's node_modules).
  */
 
-import * as _ApolloValidation from "apollo-language-server/lib/errors/validation";
 import * as _GraphQL from "graphql";
 import * as _RelayCompilerMain from "relay-compiler/lib/bin/RelayCompilerMain";
 import * as _RelayConfig from "relay-config";
@@ -54,13 +53,6 @@ export const loadDependencies = (moduleFilter: ModuleFilter, loadAdditional?: (m
     TypeInfo,
   } = mod.require("graphql") as typeof _GraphQL;
 
-  const didYouMean = mod.require("graphql/jsutils/didYouMean").default as (suggestions: string[]) => string;
-
-  const suggestionList = mod.require("graphql/jsutils/suggestionList").default as (
-    input: string,
-    options: string[]
-  ) => string[];
-
   let relayConfigMod: typeof _RelayConfig | null = null;
   try {
     // tslint:disable-next-line: no-var-requires
@@ -87,8 +79,6 @@ export const loadDependencies = (moduleFilter: ModuleFilter, loadAdditional?: (m
   const RelayCompilerMain = relayCompilerMainMod;
   return {
     ...(loadAdditional ? loadAdditional(mod) : {}),
-    didYouMean,
-    suggestionList,
     RelayConfig,
     RelayCompilerMain,
     BREAK,

--- a/packages/generate-config/tests/generateConfig-test.ts
+++ b/packages/generate-config/tests/generateConfig-test.ts
@@ -1,0 +1,60 @@
+import type { ValidationRule } from "graphql";
+import { Config } from "relay-compiler/lib/bin/RelayCompilerMain";
+import { generateConfig } from "../src/index";
+
+jest.mock("cosmiconfig", () => () => ({
+  searchSync: () => ({
+    config: {
+      schema: "path/to/schema.graphql",
+      src: "path/to/src-root",
+      exclude: ["path/to/exclude"],
+    } as Config,
+  }),
+}));
+
+const moduleId = "graphql.vscode-graphql";
+
+describe(generateConfig, () => {
+  xdescribe("when user does not use relay-config", () => {
+    it("uses a default schema file", () => {
+      jest.mock("relay-config", () => ({ loadConfig: () => null }));
+      const config = generateConfig(moduleId);
+      expect(config.schema).toEqual("./data/schema.graphql");
+    });
+
+    it("uses a default source root", () => {
+      jest.mock("relay-config", () => ({ loadConfig: () => null }));
+      const config = generateConfig(moduleId);
+      expect(config.include).toEqual("./src/**/*.{graphql,js,jsx}");
+    });
+  });
+
+  it("specifies the schema file", () => {
+    const config = generateConfig(moduleId);
+    expect(config.schema).toEqual("path/to/schema.graphql");
+  });
+
+  it("specifies the source files to include", () => {
+    const config = generateConfig(moduleId);
+    expect(config.include).toContain("path/to/src-root/**/*.{graphql,js,jsx}");
+  });
+
+  it("specifies the source files to exclude", () => {
+    const config = generateConfig(moduleId);
+    expect(config.exclude).toContain("path/to/exclude");
+  });
+
+  it("excludes validation rules that are incompatible with Relay", () => {
+    const config = generateConfig(moduleId);
+    const rules = config.validationRules as ValidationRule[];
+    expect(rules.map(({ name }) => name)).not.toContain("NoUndefinedVariablesRule");
+  });
+
+  it("includes the RelayUnknownArgumentNames validation rule", () => {
+    const config = generateConfig(moduleId);
+    const rules = config.validationRules as ValidationRule[];
+    expect(rules.map(({ name }) => name)).toContain("RelayKnownArgumentNames");
+  });
+
+  it.todo("specifies the source files to include with a different language plugin");
+});

--- a/packages/generate-config/tsconfig.json
+++ b/packages/generate-config/tsconfig.json
@@ -5,5 +5,10 @@
     "rootDir": "./src",
     "outDir": "./dist",
     "composite": true
-  }
+  },
+  "references": [
+    {
+      "path": "../validation-rules"
+    }
+  ]
 }

--- a/packages/graphql-config/src/generateConfig.ts
+++ b/packages/graphql-config/src/generateConfig.ts
@@ -1,40 +1,23 @@
 import { ValidationRule } from "graphql";
-import type { GraphQLProjectConfig } from "graphql-config";
+import type { IGraphQLProject } from "graphql-config";
 
 import { generateConfig as generateConfigFromRelay } from "@relay-graphql-js/generate-config";
-import {
-  RelayArgumentsOfCorrectType,
-  RelayCompatMissingConnectionDirective,
-  RelayCompatRequiredPageInfoFields,
-  RelayDefaultValueOfCorrectType,
-  RelayKnownVariableNames,
-  RelayNoUnusedArguments,
-  RelayVariablesInAllowedPosition,
-} from "@relay-graphql-js/validation-rules";
 
-export function generateConfig(compat: boolean = false, customValidationRules: ValidationRule[] = []) {
-  const { schema, includes, excludes, includesGlobPattern, directivesFile } = generateConfigFromRelay(
-    "graphql.vscode-graphql"
+export function generateConfig(compat?: boolean, customValidationRules: ValidationRule[] = []) {
+  const { schema, include, exclude, includesGlobPattern, directivesFile, validationRules } = generateConfigFromRelay(
+    "graphql.vscode-graphql",
+    compat
   );
-  const compatOnlyRules = compat ? [RelayCompatRequiredPageInfoFields, RelayCompatMissingConnectionDirective] : [];
 
-  const config = {
+  const config: IGraphQLProject = {
     schema: [schema, directivesFile],
-    includes,
-    excludes,
-    documents: includes,
+    include,
+    exclude,
+    documents: [...include],
     extensions: {
-      customValidationRules: [
-        RelayKnownVariableNames,
-        RelayVariablesInAllowedPosition,
-        RelayArgumentsOfCorrectType,
-        RelayDefaultValueOfCorrectType,
-        RelayNoUnusedArguments,
-        ...compatOnlyRules,
-        ...customValidationRules,
-      ],
+      customValidationRules: [...validationRules, ...customValidationRules],
     },
-  } as Partial<GraphQLProjectConfig>;
+  };
 
   return { config, directivesFile, includesGlobPattern };
 }

--- a/packages/graphql-config/tests/generateConfig-test.ts
+++ b/packages/graphql-config/tests/generateConfig-test.ts
@@ -1,0 +1,63 @@
+import type { ValidationRule } from "graphql";
+import { Config } from "relay-compiler/lib/bin/RelayCompilerMain";
+import { generateConfig } from "../src/index";
+
+jest.mock("cosmiconfig", () => () => ({
+  searchSync: () => ({
+    config: {
+      schema: "path/to/schema.graphql",
+      src: "path/to/src-root",
+      exclude: ["path/to/exclude"],
+    } as Config,
+  }),
+}));
+
+describe(generateConfig, () => {
+  xdescribe("when user does not use relay-config", () => {
+    it("uses a default schema file", () => {
+      jest.mock("relay-config", () => ({ loadConfig: () => null }));
+      const config = generateConfig();
+      expect(config.config.schema).toContainEqual(expect.stringMatching("./data/schema.graphql"));
+    });
+
+    it("uses a default source root", () => {
+      jest.mock("relay-config", () => ({ loadConfig: () => null }));
+      const config = generateConfig();
+      expect(config.config.include).toEqual("./src/**/*.{graphql,js,jsx}");
+    });
+  });
+
+  it("specifies the schema file", () => {
+    const config = generateConfig();
+    expect(config.config.schema).toContainEqual(expect.stringMatching("path/to/schema.graphql"));
+  });
+
+  it("specifies the source files to include", () => {
+    const config = generateConfig();
+    expect(config.config.include).toContain("path/to/src-root/**/*.{graphql,js,jsx}");
+  });
+
+  it("specifies the source files to exclude", () => {
+    const config = generateConfig();
+    expect(config.config.exclude).toContain("path/to/exclude");
+  });
+
+  it("excludes validation rules that are incompatible with Relay", () => {
+    const config = generateConfig();
+    const rules = config.config.extensions?.customValidationRules as ValidationRule[];
+    expect(rules.map(({ name }) => name)).not.toContain("NoUndefinedVariablesRule");
+  });
+
+  it("includes the RelayUnknownArgumentNames validation rule", () => {
+    const config = generateConfig();
+    const rules = config.config.extensions?.customValidationRules as ValidationRule[];
+    expect(rules.map(({ name }) => name)).toContain("RelayKnownArgumentNames");
+  });
+
+  it("specifies the relay-compiler directives dump to schema", () => {
+    const config = generateConfig();
+    expect(config.config.schema).toContainEqual(expect.stringMatching(/relay-compiler-directives-v\d+\.\d+\.\d+/));
+  });
+
+  it.todo("specifies the source files to include with a different language plugin");
+});

--- a/packages/validation-rules/src/RelayKnownArgumentNames.ts
+++ b/packages/validation-rules/src/RelayKnownArgumentNames.ts
@@ -6,83 +6,78 @@ import type {
   TypeNode,
   ValidationContext,
   ValidationRule,
-} from "graphql"
-import { GraphQLError, parseType, visit } from "graphql"
+} from "graphql";
+import { GraphQLError, KnownArgumentNamesRule, parseType, visit } from "graphql";
 
-import { containsVariableNodes, getArgumentDefinitions } from "@relay-graphql-js/validation-rules"
-
-import { defaultValidationRules, didYouMean, suggestionList } from "./dependencies"
-
-const KnownArgumentNames: ValidationRule = defaultValidationRules.find((rule: ValidationRule) =>
-  rule.name.startsWith("KnownArgumentNames")
-)!
+import { getArgumentDefinitions } from "./argumentDefinitions";
+import { containsVariableNodes } from "./utils";
 
 // tslint:disable-next-line: no-shadowed-variable
 export const RelayKnownArgumentNames: ValidationRule = function RelayKnownArgumentNames(context) {
-  const originalRuleVisitor = KnownArgumentNames(context)
+  const originalRuleVisitor = KnownArgumentNamesRule(context);
   return {
     Argument(argumentNode) {
       /**
        * Always forward field arguments to the original rule.
        */
-      visit(argumentNode, originalRuleVisitor)
-      return false
+      visit(argumentNode, originalRuleVisitor);
+      return false;
     },
     FragmentSpread(fragmentSpreadNode) {
-      const fragmentDefinitionNode = context.getFragment(fragmentSpreadNode.name.value)
+      const fragmentDefinitionNode = context.getFragment(fragmentSpreadNode.name.value);
       if (
         fragmentDefinitionNode &&
         (!fragmentSpreadNode.directives ||
           fragmentSpreadNode.directives.findIndex((directive) => directive.name.value === "arguments") === -1) &&
         getArgumentDefinitions(fragmentDefinitionNode)
       ) {
-        validateFragmentArguments(context, fragmentDefinitionNode, fragmentSpreadNode)
+        validateFragmentArguments(context, fragmentDefinitionNode, fragmentSpreadNode);
       }
     },
     Directive(directiveNode, _key, _parent, _nodePath, ancestors) {
       if (directiveNode.name.value === "argumentDefinitions") {
-        validateFragmentArgumentDefinitions(context, directiveNode)
-        return false
+        validateFragmentArgumentDefinitions(context, directiveNode);
+        return false;
       }
       if (directiveNode.name.value === "arguments") {
-        const fragmentSpreadNode = ancestors[ancestors.length - 1] as FragmentSpreadNode
-        const fragmentDefinitionNode = context.getFragment(fragmentSpreadNode.name.value)
+        const fragmentSpreadNode = ancestors[ancestors.length - 1] as FragmentSpreadNode;
+        const fragmentDefinitionNode = context.getFragment(fragmentSpreadNode.name.value);
         if (fragmentDefinitionNode) {
-          validateFragmentArguments(context, fragmentDefinitionNode, fragmentSpreadNode, directiveNode)
+          validateFragmentArguments(context, fragmentDefinitionNode, fragmentSpreadNode, directiveNode);
         }
-        return false
+        return false;
       }
       /**
        * Forward any other directives to original rule.
        */
-      visit(directiveNode, originalRuleVisitor)
-      return false
+      visit(directiveNode, originalRuleVisitor);
+      return false;
     },
-  }
-}
+  };
+};
 
 function validateFragmentArgumentDefinitions(context: ValidationContext, directiveNode: DirectiveNode) {
   if (!directiveNode.arguments || directiveNode.arguments.length === 0) {
-    context.reportError(new GraphQLError(`Missing required argument definitions.`, directiveNode))
+    context.reportError(new GraphQLError(`Missing required argument definitions.`, directiveNode));
   } else {
     directiveNode.arguments.forEach((argumentNode) => {
-      const metadataNode = argumentNode.value
+      const metadataNode = argumentNode.value;
       if (metadataNode.kind !== "ObjectValue" || !metadataNode.fields.some((field) => field.name.value === "type")) {
         context.reportError(
           new GraphQLError(
             `Metadata of argument definition should be of type "Object" with a "type" and optional "defaultValue" key.`,
             metadataNode
           )
-        )
+        );
       } else {
         metadataNode.fields.forEach((fieldNode) => {
-          const name = fieldNode.name.value
+          const name = fieldNode.name.value;
           if (name !== "type" && name !== "defaultValue") {
             context.reportError(
               new GraphQLError(`Unknown key "${name}" in argument definition metadata.`, fieldNode.name)
-            )
+            );
           }
-          const valueNode = fieldNode.value
+          const valueNode = fieldNode.value;
           if (name === "type") {
             if (valueNode.kind !== "StringValue") {
               context.reportError(
@@ -90,17 +85,17 @@ function validateFragmentArgumentDefinitions(context: ValidationContext, directi
                   `Value for "type" in argument definition metadata must be specified as string literal.`,
                   valueNode
                 )
-              )
+              );
             } else {
-              let typeNode: TypeNode | null = null
+              let typeNode: TypeNode | null = null;
               try {
-                typeNode = parseType(valueNode.value)
+                typeNode = parseType(valueNode.value);
               } catch (error) {
-                context.reportError(new GraphQLError(error.message, valueNode))
+                context.reportError(new GraphQLError(error.message, valueNode));
               }
               if (typeNode) {
                 while (typeNode.kind === "NonNullType" || typeNode.kind === "ListType") {
-                  typeNode = typeNode.type
+                  typeNode = typeNode.type;
                 }
                 if (!context.getSchema().getType(typeNode.name.value)) {
                   context.reportError(
@@ -108,7 +103,7 @@ function validateFragmentArgumentDefinitions(context: ValidationContext, directi
                       `Unknown type "${typeNode.name.value}" in argument definition metadata.`,
                       valueNode
                     )
-                  )
+                  );
                 }
               }
             }
@@ -119,29 +114,29 @@ function validateFragmentArgumentDefinitions(context: ValidationContext, directi
                   `defaultValue contains variables for argument ${argumentNode.name.value} in argument definition metadata.`,
                   valueNode
                 )
-              )
+              );
             }
           }
-        })
+        });
       }
-    })
+    });
   }
 }
 
 function isNullableArgument(argumentDefinition: ObjectValueNode): boolean {
-  const typeField = argumentDefinition.fields.find((f) => f.name.value === "type")
+  const typeField = argumentDefinition.fields.find((f) => f.name.value === "type");
   if (typeField == null) {
-    return false
+    return false;
   }
 
   if (typeField.value.kind !== "StringValue") {
-    return false
+    return false;
   }
   try {
-    const type = parseType(typeField.value.value)
-    return type.kind !== "NonNullType"
+    const type = parseType(typeField.value.value);
+    return type.kind !== "NonNullType";
   } catch (e) {
-    return false
+    return false;
   }
 }
 
@@ -151,22 +146,25 @@ function validateFragmentArguments(
   fragmentSpreadNode: FragmentSpreadNode,
   directiveNode?: DirectiveNode
 ) {
-  const argumentDefinitionNodes = getArgumentDefinitions(fragmentDefinitionNode)
+  const argumentDefinitionNodes = getArgumentDefinitions(fragmentDefinitionNode);
+  const suggestionList = require("graphql/jsutils/suggestionList").default;
+  const didYouMean = require("graphql/jsutils/didYouMean").default;
+
   if (!argumentDefinitionNodes) {
     context.reportError(
       new GraphQLError(
         `No fragment argument definitions exist for fragment "${fragmentSpreadNode.name.value}".`,
         fragmentSpreadNode
       )
-    )
+    );
   } else {
-    const argumentNodes = [...((directiveNode && directiveNode.arguments) || [])]
+    const argumentNodes = [...((directiveNode && directiveNode.arguments) || [])];
     argumentDefinitionNodes.forEach((argumentDef) => {
-      const argumentIndex = argumentNodes.findIndex((a) => a.name.value === argumentDef.name.value)
+      const argumentIndex = argumentNodes.findIndex((a) => a.name.value === argumentDef.name.value);
       if (argumentIndex >= 0) {
-        argumentNodes.splice(argumentIndex, 1)
+        argumentNodes.splice(argumentIndex, 1);
       } else {
-        const value = argumentDef.value
+        const value = argumentDef.value;
         if (value.kind === "ObjectValue") {
           if (
             value.fields.findIndex((field) => field.name.value === "defaultValue") === -1 &&
@@ -177,24 +175,24 @@ function validateFragmentArguments(
                 `Missing required fragment argument "${argumentDef.name.value}".`,
                 directiveNode || fragmentSpreadNode
               )
-            )
+            );
           }
         } else {
-          console.log(`Unexpected fragment argument value kind "${value.kind}".`)
+          console.log(`Unexpected fragment argument value kind "${value.kind}".`);
         }
       }
-    })
+    });
     argumentNodes.forEach((argumentNode) => {
       const suggestions: string[] = suggestionList(
         argumentNode.name.value,
         argumentDefinitionNodes.map((argDef) => argDef.name.value)
-      )
+      );
       context.reportError(
         new GraphQLError(
           `Unknown fragment argument "${argumentNode.name.value}".` + didYouMean(suggestions.map((x) => `"${x}"`)),
           directiveNode
         )
-      )
-    })
+      );
+    });
   }
 }

--- a/packages/validation-rules/src/index.ts
+++ b/packages/validation-rules/src/index.ts
@@ -2,6 +2,7 @@ export { RelayArgumentsOfCorrectType } from "./RelayArgumentsOfCorrectType";
 export { RelayCompatMissingConnectionDirective } from "./RelayCompatMissingConnectionDirective";
 export { RelayCompatRequiredPageInfoFields } from "./RelayCompatRequiredPageInfoFields";
 export { RelayDefaultValueOfCorrectType } from "./RelayDefaultValueOfCorrectType";
+export { RelayKnownArgumentNames } from "./RelayKnownArgumentNames";
 export { RelayKnownVariableNames } from "./RelayKnownVariableNames";
 export { RelayNoUnusedArguments } from "./RelayNoUnusedArguments";
 export { RelayVariablesInAllowedPosition } from "./RelayVariablesInAllowedPosition";

--- a/packages/validation-rules/tests/RelayKnownArgumentNames-test.ts
+++ b/packages/validation-rules/tests/RelayKnownArgumentNames-test.ts
@@ -1,7 +1,7 @@
-import { readFileSync } from "fs"
-import { buildSchema, parse, validate } from "graphql"
-import { generateDirectivesFile } from "@relay-graphql-js/generate-config"
-import { RelayKnownArgumentNames } from "../src/RelayKnownArgumentNames"
+import { readFileSync } from "fs";
+import { buildSchema, parse, validate } from "graphql";
+import { generateDirectivesFile } from "@relay-graphql-js/generate-config";
+import { RelayKnownArgumentNames } from "../src/RelayKnownArgumentNames";
 
 const schema = buildSchema(`
 ${readFileSync(generateDirectivesFile(), "utf8")}
@@ -14,10 +14,10 @@ type Foo {
 type Query {
   foo: Foo
 }
-`)
+`);
 
 function validateDocuments(source: string) {
-  return validate(schema, parse(source), [RelayKnownArgumentNames])
+  return validate(schema, parse(source), [RelayKnownArgumentNames]);
 }
 
 describe(RelayKnownArgumentNames, () => {
@@ -27,13 +27,13 @@ describe(RelayKnownArgumentNames, () => {
       fragment FragmentWithFieldArgument on Foo {
         bar(az: true)
       }
-      `)
+      `);
       expect(errors).toContainEqual(
         expect.objectContaining({
           message: `Unknown argument "az" on field "bar" of type "Foo".`,
         })
-      )
-    })
+      );
+    });
 
     it("validates directive arguments", () => {
       const errors = validateDocuments(`
@@ -43,14 +43,14 @@ describe(RelayKnownArgumentNames, () => {
         fragment OtherFragment on Foo {
           bar
         }
-        `)
+        `);
       expect(errors).toContainEqual(
         expect.objectContaining({
           message: `Unknown argument "ask" on directive "@relay". Did you mean "mask"?`,
         })
-      )
-    })
-  })
+      );
+    });
+  });
 
   describe("concerning fragment argument definitions", () => {
     it("validates that argument definitions get a list", () => {
@@ -58,13 +58,13 @@ describe(RelayKnownArgumentNames, () => {
         fragment FragmentWithoutArguments on Foo @argumentDefinitions {
           bar
         }
-      `)
+      `);
       expect(errors).toContainEqual(
         expect.objectContaining({
           message: `Missing required argument definitions.`,
         })
-      )
-    })
+      );
+    });
 
     it("validates that argument definitions exist", () => {
       const errors = validateDocuments(`
@@ -75,13 +75,13 @@ describe(RelayKnownArgumentNames, () => {
         fragment FragmentSpreadWithArguments on Foo {
           ...FragmentWithoutArguments @arguments(someArgument: "something")
         }
-      `)
+      `);
       expect(errors).toContainEqual(
         expect.objectContaining({
           message: `No fragment argument definitions exist for fragment "FragmentWithoutArguments".`,
         })
-      )
-    })
+      );
+    });
 
     it("validates that the argument definition is an object", () => {
       const errors = validateDocuments(`
@@ -90,13 +90,13 @@ describe(RelayKnownArgumentNames, () => {
         ) {
           bar
         }
-      `)
+      `);
       expect(errors).toContainEqual(
         expect.objectContaining({
           message: `Metadata of argument definition should be of type "Object" with a "type" and optional "defaultValue" key.`,
         })
-      )
-    })
+      );
+    });
 
     it("validates that a `type` is specified", () => {
       const errors = validateDocuments(`
@@ -105,13 +105,13 @@ describe(RelayKnownArgumentNames, () => {
         ) {
           bar
         }
-      `)
+      `);
       expect(errors).toContainEqual(
         expect.objectContaining({
           message: `Metadata of argument definition should be of type "Object" with a "type" and optional "defaultValue" key.`,
         })
-      )
-    })
+      );
+    });
 
     it("validates that no unknown fields exist in metadata", () => {
       const errors = validateDocuments(`
@@ -120,13 +120,13 @@ describe(RelayKnownArgumentNames, () => {
         ) {
           bar
         }
-      `)
+      `);
       expect(errors).toContainEqual(
         expect.objectContaining({
           message: `Unknown key "foo" in argument definition metadata.`,
         })
-      )
-    })
+      );
+    });
 
     it("validates that the type is specified as a string value", () => {
       const errors = validateDocuments(`
@@ -135,13 +135,13 @@ describe(RelayKnownArgumentNames, () => {
         ) {
           bar
         }
-      `)
+      `);
       expect(errors).toContainEqual(
         expect.objectContaining({
           message: `Value for "type" in argument definition metadata must be specified as string literal.`,
         })
-      )
-    })
+      );
+    });
 
     it("validates that the defaultValue contains no variables", () => {
       const errors = validateDocuments(`
@@ -150,13 +150,13 @@ describe(RelayKnownArgumentNames, () => {
         ) {
           bar
         }
-      `)
+      `);
       expect(errors).toContainEqual(
         expect.objectContaining({
           message: `Value for "type" in argument definition metadata must be specified as string literal.`,
         })
-      )
-    })
+      );
+    });
 
     it("validates that the type is valid", () => {
       const errors = validateDocuments(`
@@ -167,26 +167,26 @@ describe(RelayKnownArgumentNames, () => {
         ) {
           bar
         }
-      `)
+      `);
       expect(errors).toContainEqual(
         expect.objectContaining({
           message: `Unknown type "Bar" in argument definition metadata.`,
         })
-      )
+      );
       expect(errors).toContainEqual(
         expect.objectContaining({
           message: `Unknown type "Baz" in argument definition metadata.`,
         })
-      )
+      );
       expect(errors).toContainEqual(
         expect.objectContaining({
           message: `Syntax Error: Expected Name, found Int "10"`,
         })
-      )
-    })
+      );
+    });
 
-    it.todo("validates that the defaultValue matches type")
-  })
+    it.todo("validates that the defaultValue matches type");
+  });
 
   describe("concerning fragment arguments", () => {
     it("validates that required arguments exist in list", () => {
@@ -201,11 +201,11 @@ describe(RelayKnownArgumentNames, () => {
         fragment FragmentSpreadWithMissingArgument on Foo {
           ...FragmentWithArguments @arguments(optionalArgument: "something")
         }
-      `)
+      `);
       expect(errors).toContainEqual(
         expect.objectContaining({ message: `Missing required fragment argument "requiredArgument".` })
-      )
-    })
+      );
+    });
 
     it("considers nullable arguments as optional", () => {
       const errors = validateDocuments(`
@@ -219,9 +219,9 @@ describe(RelayKnownArgumentNames, () => {
         fragment FragmentSpreadWithMissingArgument on Foo {
           ...FragmentWithArguments @arguments(requiredArgument: "something")
         }
-      `)
-      expect(errors).toEqual([])
-    })
+      `);
+      expect(errors).toEqual([]);
+    });
 
     it("validates required arguments when no list is given", () => {
       const errors = validateDocuments(`
@@ -234,11 +234,11 @@ describe(RelayKnownArgumentNames, () => {
         fragment FragmentSpreadWithMissingArgument on Foo {
           ...FragmentWithArguments @arguments
         }
-      `)
+      `);
       expect(errors).toContainEqual(
         expect.objectContaining({ message: `Missing required fragment argument "requiredArgument".` })
-      )
-    })
+      );
+    });
 
     it.only("validates required arguments when no @arguments directive is used", () => {
       const errors = validateDocuments(`
@@ -251,11 +251,11 @@ describe(RelayKnownArgumentNames, () => {
         fragment FragmentSpreadWithMissingArgument on Foo {
           ...FragmentWithArguments
         }
-      `)
+      `);
       expect(errors).toContainEqual(
         expect.objectContaining({ message: `Missing required fragment argument "requiredArgument".` })
-      )
-    })
+      );
+    });
 
     it("suggests alternatives when argument is unknown", () => {
       const errors = validateDocuments(`
@@ -268,12 +268,12 @@ describe(RelayKnownArgumentNames, () => {
         fragment FragmentSpreadWithMissingArgument on Foo {
           ...FragmentWithArguments @arguments(equiredArgument: "whoops")
         }
-      `)
+      `);
       expect(errors).toContainEqual(
         expect.objectContaining({
           message: `Unknown fragment argument "equiredArgument". Did you mean "requiredArgument"?`,
         })
-      )
-    })
-  })
-})
+      );
+    });
+  });
+});

--- a/packages/validation-rules/tsconfig.json
+++ b/packages/validation-rules/tsconfig.json
@@ -5,10 +5,5 @@
     "rootDir": "./src",
     "outDir": "./dist",
     "composite": true
-  },
-  "references": [
-    {
-      "path": "../generate-config"
-    }
-  ]
+  }
 }

--- a/packages/vscode-apollo-relay/package.json
+++ b/packages/vscode-apollo-relay/package.json
@@ -32,7 +32,6 @@
     "release": "standard-version"
   },
   "dependencies": {
-    "@relay-graphql-js/validation-rules": "^0.0.1",
     "@relay-graphql-js/generate-config": "^0.0.1"
   },
   "devDependencies": {

--- a/packages/vscode-apollo-relay/src/dependencies.ts
+++ b/packages/vscode-apollo-relay/src/dependencies.ts
@@ -2,13 +2,11 @@ import * as _ApolloValidation from "apollo-language-server/lib/errors/validation
 
 import { loadDependencies } from "@relay-graphql-js/generate-config"
 
-const { KnownArgumentNames, didYouMean, suggestionList, defaultValidationRules } = loadDependencies(
-  "apollographql.vscode-apollo",
-  (mod: NodeModule) => {
-    return {
-      defaultValidationRules: mod.require("apollo-language-server/lib/errors/validation")
-        .defaultValidationRules as typeof _ApolloValidation,
-    }
+const extensionId = "apollographql.vscode-apollo"
+const { defaultValidationRules } = loadDependencies(extensionId, (mod: NodeModule) => {
+  return {
+    defaultValidationRules: mod.require("apollo-language-server/lib/errors/validation")
+      .defaultValidationRules as typeof _ApolloValidation,
   }
-)
-export { KnownArgumentNames, didYouMean, suggestionList, defaultValidationRules }
+})
+export { defaultValidationRules, extensionId }

--- a/packages/vscode-apollo-relay/src/generateConfig.ts
+++ b/packages/vscode-apollo-relay/src/generateConfig.ts
@@ -2,18 +2,8 @@ import type { ApolloConfigFormat } from "apollo-language-server/lib/config"
 import type { ValidationRule } from "graphql"
 
 import { generateConfig as generateConfigFromRelay } from "@relay-graphql-js/generate-config"
-import {
-  RelayArgumentsOfCorrectType,
-  RelayCompatMissingConnectionDirective,
-  RelayCompatRequiredPageInfoFields,
-  RelayDefaultValueOfCorrectType,
-  RelayKnownVariableNames,
-  RelayNoUnusedArguments,
-  RelayVariablesInAllowedPosition,
-} from "@relay-graphql-js/validation-rules"
 
-import { defaultValidationRules } from "./dependencies"
-import { RelayKnownArgumentNames } from "./RelayKnownArgumentNames"
+import { defaultValidationRules, extensionId } from "./dependencies"
 
 const ValidationRulesToExcludeForRelay = [
   "KnownArgumentNames",
@@ -23,10 +13,10 @@ const ValidationRulesToExcludeForRelay = [
 ]
 
 export function generateConfig(compat: boolean = false) {
-  const { schema, includes, excludes, includesGlobPattern, directivesFile } = generateConfigFromRelay(
-    "apollographql.vscode-apollo"
+  const { schema, include, exclude, includesGlobPattern, directivesFile, validationRules } = generateConfigFromRelay(
+    extensionId,
+    compat
   )
-  const compatOnlyRules = compat ? [RelayCompatRequiredPageInfoFields, RelayCompatMissingConnectionDirective] : []
 
   const config: ApolloConfigFormat = {
     client: {
@@ -35,19 +25,13 @@ export function generateConfig(compat: boolean = false) {
         localSchemaFile: schema,
       },
       validationRules: [
-        RelayKnownArgumentNames,
-        RelayKnownVariableNames,
-        RelayVariablesInAllowedPosition,
-        RelayArgumentsOfCorrectType,
-        RelayDefaultValueOfCorrectType,
-        RelayNoUnusedArguments,
-        ...compatOnlyRules,
+        ...validationRules,
         ...defaultValidationRules.filter(
           (rule: ValidationRule) => !ValidationRulesToExcludeForRelay.some((name) => rule.name.startsWith(name))
         ),
       ],
-      includes,
-      excludes,
+      includes: [...include, directivesFile],
+      excludes: exclude,
       tagName: "graphql",
     },
   }


### PR DESCRIPTION
### improvements
- use `RelayKnownArgumentNames` in both configs
- export `validationRules` from `generateConfig`

### tests
- add tests
- jest config for coverage
###  tooling updates
- use `main` for `baseBranch` in `changeset`, thats the issue!