### PR TITLE
chore: fix `module.parent` deprecated

### DIFF
--- a/.changeset/spotty-squids-film.md
+++ b/.changeset/spotty-squids-film.md
@@ -1,0 +1,5 @@
+---
+"@relay-graphql-js/generate-config": patch
+---
+
+chore: fix `module.parent` deprecated according to #21

--- a/packages/generate-config/src/dependencies.ts
+++ b/packages/generate-config/src/dependencies.ts
@@ -25,7 +25,7 @@ function moduleFromDependencyModules(moduleFilter: ModuleFilter) {
   let mod = module;
   if (typeof jest === "undefined") {
     while (filterModules(mod, moduleFilter)) {
-      mod = mod.parent!;
+      mod = Object.values(require.cache).filter((m) => m.children.includes(module))[0] ?? null;
     }
     if (mod === null) {
       throw new Error(`Unable to find ${moduleFilter}'s node_modules`);


### PR DESCRIPTION
Resolves #21.